### PR TITLE
chore(dockerfile): remove langid

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,7 @@ COPY . .
 
 RUN apt update && apt install -y build-essential portaudio19-dev
 
-# ModuleNotFoundError: No module named 'langid'
-RUN --mount=type=cache,target=/root/.cache/pip python -m pip install langid /app
+RUN --mount=type=cache,target=/root/.cache/pip python -m pip install /app
 
 ENTRYPOINT [ "auralis.openai" ]
 


### PR DESCRIPTION
https://github.com/astramind-ai/Auralis/pull/26#issuecomment-2519655749
https://github.com/astramind-ai/Auralis/issues/36
https://github.com/astramind-ai/Auralis/commit/92bc90a0e30616348c2a56707e60c4d01851cce4

Now that `langid` is in the dependency list, removing it from the Dockerfile is safe.